### PR TITLE
Fixed Witcher 3 HBAO+ normal map artifacts

### DIFF
--- a/Witcher3/Helifax_Update_1.22_3DM.1.2.40/ShaderFixes/34b661ef093bad26-ps_replace.txt
+++ b/Witcher3/Helifax_Update_1.22_3DM.1.2.40/ShaderFixes/34b661ef093bad26-ps_replace.txt
@@ -1,0 +1,635 @@
+// ---- Created with 3Dmigoto v1.2.46 on Sun Nov 20 14:09:26 2016
+Texture2D<float4> t1 : register(t1);
+
+Texture2DArray<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[2];
+}
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[4];
+}
+
+// from VS
+cbuffer cb13 : register(b13)
+{
+  float4 cb13[214];
+  // cb13[13]- cb13[16]: forward projection matrix
+}
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+Texture1D<float4> IniParams : register(t120);
+Texture2D<float4> StereoParams : register(t125);
+
+
+void main( 
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+  
+float4 stereo = StereoParams.Load(0);
+float fov = 1.5 / cb13[13].x;			// 1.5: fudge constant
+
+  r0.xy = floor(v0.xy);
+  r0.xy = r0.xy * float2(4,4) + cb2[1].xy;
+  r0.zw = cb0[0].xy * r0.xy;
+  r1.xy = float2(0.25,0.25) * r0.zw;
+  r1.z = 0;
+  r2.z = t0.SampleLevel(s0_s, r1.xyz, 0).x;
+  r0.z = cb0[2].x / r2.z;
+  r0.w = cmp(r0.z < 1);
+  if (r0.w != 0) {
+    o0.x = 1;
+    return;
+  }
+  r1.zw = cb0[1].xy * r1.xy + cb0[1].zw;
+  r2.xy = r1.zw * r2.zz;
+
+r2.x -= (r2.z - stereo.y) * stereo.x * fov;
+  
+  r3.xy = (int2)r0.xy;
+  r3.zw = float2(0,0);
+  r3.xyzw = t1.Load(r3.xyz).xyzw;
+  r0.xyw = r3.xyz * float3(2,2,2) + float3(-1,-1,-1);
+  r1.z = cb0[3].x * r3.w;
+  r1.w = 0.0500000007 * r0.z;
+  r1.w = cb2[0].z * r1.w + 1;
+  r3.xy = cb2[0].xy * r1.ww;
+  r3.xy = round(r3.xy);
+  r3.xy = r3.xy * cb0[0].xy + r1.xy;
+  r3.z = 0;
+  r4.z = t0.SampleLevel(s0_s, r3.xyz, 0).x;
+  r3.xy = cb0[1].xy * r3.xy + cb0[1].zw;
+  r4.xy = r3.xy * r4.zz;
+  
+r4.x -= (r4.z - stereo.y) * stereo.x * fov;
+  
+  r2.w = r0.z * 0.0500000007 + r1.w;
+  r3.xyz = r4.xyz + -r2.xyz;
+  r3.w = dot(r3.xyz, r3.xyz);
+  r3.x = dot(r0.xyw, r3.xyz);
+  r3.y = rsqrt(r3.w);
+  r3.x = saturate(r3.x * r3.y + -cb0[2].w);
+  r3.y = saturate(r3.w * cb0[2].z + 1);
+  r3.zw = cb2[0].xy * r2.ww;
+  r3.zw = round(r3.zw);
+  r4.xy = r3.zw * cb0[0].xy + r1.xy;
+  r4.z = 0;
+  r5.z = t0.SampleLevel(s0_s, r4.xyz, 0).x;
+  r3.zw = cb0[1].xy * r4.xy + cb0[1].zw;
+  r5.xy = r3.zw * r5.zz;
+  
+r5.x -= (r5.z - stereo.y) * stereo.x * fov;
+  
+  r3.z = r0.z * 0.0500000007 + r2.w;
+  r4.xyz = r5.xyz + -r2.xyz;
+  r3.w = dot(r4.xyz, r4.xyz);
+  r4.x = dot(r0.xyw, r4.xyz);
+  r4.y = rsqrt(r3.w);
+  r4.x = saturate(r4.x * r4.y + -cb0[2].w);
+  r3.w = saturate(r3.w * cb0[2].z + 1);
+  r3.w = r4.x * r3.w;
+  r3.x = r3.x * r3.y + r3.w;
+  r3.yw = cb2[0].xy * r3.zz;
+  r3.yw = round(r3.yw);
+  r4.xy = r3.yw * cb0[0].xy + r1.xy;
+  r4.z = 0;
+  r5.z = t0.SampleLevel(s0_s, r4.xyz, 0).x;
+  r3.yw = cb0[1].xy * r4.xy + cb0[1].zw;
+  r5.xy = r3.yw * r5.zz;
+  
+r5.x -= (r5.z - stereo.y) * stereo.x * fov;
+  
+  r0.z = r0.z * 0.0500000007 + r3.z;
+  r4.xyz = r5.xyz + -r2.xyz;
+  r3.y = dot(r4.xyz, r4.xyz);
+  r3.w = dot(r0.xyw, r4.xyz);
+  r4.x = rsqrt(r3.y);
+  r3.w = saturate(r3.w * r4.x + -cb0[2].w);
+  r3.y = saturate(r3.y * cb0[2].z + 1);
+  r3.x = r3.w * r3.y + r3.x;
+  r3.yw = cb2[0].xy * r0.zz;
+  r3.yw = round(r3.yw);
+  r4.xy = r3.yw * cb0[0].xy + r1.xy;
+  r4.z = 0;
+  r5.z = t0.SampleLevel(s0_s, r4.xyz, 0).x;
+  r3.yw = cb0[1].xy * r4.xy + cb0[1].zw;
+  r5.xy = r3.yw * r5.zz;
+  
+r5.x -= (r5.z - stereo.y) * stereo.x * fov;
+  
+  r4.xyz = r5.xyz + -r2.xyz;
+  r3.y = dot(r4.xyz, r4.xyz);
+  r3.w = dot(r0.xyw, r4.xyz);
+  r4.x = rsqrt(r3.y);
+  r3.w = saturate(r3.w * r4.x + -cb0[2].w);
+  r3.y = saturate(r3.y * cb0[2].z + 1);
+  r3.x = r3.w * r3.y + r3.x;
+  r3.yw = float2(0.707106769,0.707106769) * cb2[0].xy;
+  r4.x = cb2[0].x * 0.707106769 + -r3.w;
+  r4.y = r3.w + r3.y;
+  r4.zw = r4.xy * r1.ww;
+  r4.zw = round(r4.zw);
+  r5.xy = r4.zw * cb0[0].xy + r1.xy;
+  r5.z = 0;
+  r6.z = t0.SampleLevel(s0_s, r5.xyz, 0).x;
+  r4.zw = cb0[1].xy * r5.xy + cb0[1].zw;
+  r6.xy = r4.zw * r6.zz;
+  
+r6.x -= (r6.z - stereo.y) * stereo.x * fov;
+  
+  r5.xyz = r6.xyz + -r2.xyz;
+  r4.z = dot(r5.xyz, r5.xyz);
+  r4.w = dot(r0.xyw, r5.xyz);
+  r5.x = rsqrt(r4.z);
+  r4.w = saturate(r4.w * r5.x + -cb0[2].w);
+  r4.z = saturate(r4.z * cb0[2].z + 1);
+  r3.x = r4.w * r4.z + r3.x;
+  r4.zw = r4.xy * r2.ww;
+  r4.zw = round(r4.zw);
+  r5.xy = r4.zw * cb0[0].xy + r1.xy;
+  r5.z = 0;
+  r6.z = t0.SampleLevel(s0_s, r5.xyz, 0).x;
+  
+r6.x -= (r6.z - stereo.y) * stereo.x * fov;
+  
+  r4.zw = cb0[1].xy * r5.xy + cb0[1].zw;
+  r6.xy = r4.zw * r6.zz;
+  r5.xyz = r6.xyz + -r2.xyz;
+  r4.z = dot(r5.xyz, r5.xyz);
+  r4.w = dot(r0.xyw, r5.xyz);
+  r5.x = rsqrt(r4.z);
+  r4.w = saturate(r4.w * r5.x + -cb0[2].w);
+  r4.z = saturate(r4.z * cb0[2].z + 1);
+  r3.x = r4.w * r4.z + r3.x;
+  r4.zw = r4.xy * r3.zz;
+  r4.zw = round(r4.zw);
+  r5.xy = r4.zw * cb0[0].xy + r1.xy;
+  r5.z = 0;
+  r6.z = t0.SampleLevel(s0_s, r5.xyz, 0).x;
+  r4.zw = cb0[1].xy * r5.xy + cb0[1].zw;
+  r6.xy = r4.zw * r6.zz;
+  
+r6.x -= (r6.z - stereo.y) * stereo.x * fov;
+  
+  r5.xyz = r6.xyz + -r2.xyz;
+  r4.z = dot(r5.xyz, r5.xyz);
+  r4.w = dot(r0.xyw, r5.xyz);
+  r5.x = rsqrt(r4.z);
+  r4.w = saturate(r4.w * r5.x + -cb0[2].w);
+  r4.z = saturate(r4.z * cb0[2].z + 1);
+  r3.x = r4.w * r4.z + r3.x;
+  r4.xy = r4.xy * r0.zz;
+  r4.xy = round(r4.xy);
+  r4.xy = r4.xy * cb0[0].xy + r1.xy;
+  r4.z = 0;
+  r5.z = t0.SampleLevel(s0_s, r4.xyz, 0).x;
+  r4.xy = cb0[1].xy * r4.xy + cb0[1].zw;
+  r5.xy = r4.xy * r5.zz;
+  
+r5.x -= (r5.z - stereo.y) * stereo.x * fov;
+  
+  r4.xyz = r5.xyz + -r2.xyz;
+  r4.w = dot(r4.xyz, r4.xyz);
+  r4.x = dot(r0.xyw, r4.xyz);
+  r4.y = rsqrt(r4.w);
+  r4.x = saturate(r4.x * r4.y + -cb0[2].w);
+  r4.y = saturate(r4.w * cb0[2].z + 1);
+  r3.x = r4.x * r4.y + r3.x;
+  r4.x = cb2[0].x * 1.79489656e-009 + -cb2[0].y;
+  r4.y = cb2[0].y * 1.79489656e-009 + cb2[0].x;
+  r4.zw = r4.xy * r1.ww;
+  r4.zw = round(r4.zw);
+  r5.xy = r4.zw * cb0[0].xy + r1.xy;
+  r5.z = 0;
+  r6.z = t0.SampleLevel(s0_s, r5.xyz, 0).x;
+  r4.zw = cb0[1].xy * r5.xy + cb0[1].zw;
+  r6.xy = r4.zw * r6.zz;
+  
+r6.x -= (r6.z - stereo.y) * stereo.x * fov;
+  
+  r5.xyz = r6.xyz + -r2.xyz;
+  r4.z = dot(r5.xyz, r5.xyz);
+  r4.w = dot(r0.xyw, r5.xyz);
+  r5.x = rsqrt(r4.z);
+  r4.w = saturate(r4.w * r5.x + -cb0[2].w);
+  r4.z = saturate(r4.z * cb0[2].z + 1);
+  r3.x = r4.w * r4.z + r3.x;
+  r4.zw = r4.xy * r2.ww;
+  r4.zw = round(r4.zw);
+  r5.xy = r4.zw * cb0[0].xy + r1.xy;
+  r5.z = 0;
+  r6.z = t0.SampleLevel(s0_s, r5.xyz, 0).x;
+  r4.zw = cb0[1].xy * r5.xy + cb0[1].zw;
+  r6.xy = r4.zw * r6.zz;
+  
+r6.x -= (r6.z - stereo.y) * stereo.x * fov;
+  
+  r5.xyz = r6.xyz + -r2.xyz;
+  r4.z = dot(r5.xyz, r5.xyz);
+  r4.w = dot(r0.xyw, r5.xyz);
+  r5.x = rsqrt(r4.z);
+  r4.w = saturate(r4.w * r5.x + -cb0[2].w);
+  r4.z = saturate(r4.z * cb0[2].z + 1);
+  r3.x = r4.w * r4.z + r3.x;
+  r4.zw = r4.xy * r3.zz;
+  r4.zw = round(r4.zw);
+  r5.xy = r4.zw * cb0[0].xy + r1.xy;
+  r5.z = 0;
+  r6.z = t0.SampleLevel(s0_s, r5.xyz, 0).x;
+  r4.zw = cb0[1].xy * r5.xy + cb0[1].zw;
+  r6.xy = r4.zw * r6.zz;
+  
+r6.x -= (r6.z - stereo.y) * stereo.x * fov;
+  
+  r5.xyz = r6.xyz + -r2.xyz;
+  r4.z = dot(r5.xyz, r5.xyz);
+  r4.w = dot(r0.xyw, r5.xyz);
+  r5.x = rsqrt(r4.z);
+  r4.w = saturate(r4.w * r5.x + -cb0[2].w);
+  r4.z = saturate(r4.z * cb0[2].z + 1);
+  r3.x = r4.w * r4.z + r3.x;
+  r4.xy = r4.xy * r0.zz;
+  r4.xy = round(r4.xy);
+  r4.xy = r4.xy * cb0[0].xy + r1.xy;
+  r4.z = 0;
+  r5.z = t0.SampleLevel(s0_s, r4.xyz, 0).x;
+  r4.xy = cb0[1].xy * r4.xy + cb0[1].zw;
+  r5.xy = r4.xy * r5.zz;
+  
+r5.x -= (r5.z - stereo.y) * stereo.x * fov;
+  
+  r4.xyz = r5.xyz + -r2.xyz;
+  r4.w = dot(r4.xyz, r4.xyz);
+  r4.x = dot(r0.xyw, r4.xyz);
+  r4.y = rsqrt(r4.w);
+  r4.x = saturate(r4.x * r4.y + -cb0[2].w);
+  r4.y = saturate(r4.w * cb0[2].z + 1);
+  r3.x = r4.x * r4.y + r3.x;
+  r4.xy = float2(-0.707106769,-0.707106769) * cb2[0].xy;
+  r5.y = cb2[0].x * -0.707106769 + -r3.w;
+  r5.zw = cb2[0].yx * float2(-0.707106769,-0.707106769) + r3.yw;
+  r3.yw = r5.yz * r1.ww;
+  r3.yw = round(r3.yw);
+  r6.xy = r3.yw * cb0[0].xy + r1.xy;
+  r6.z = 0;
+  r7.z = t0.SampleLevel(s0_s, r6.xyz, 0).x;
+  r3.yw = cb0[1].xy * r6.xy + cb0[1].zw;
+  r7.xy = r3.yw * r7.zz;
+  
+r7.x -= (r7.z - stereo.y) * stereo.x * fov;
+  
+  r6.xyz = r7.xyz + -r2.xyz;
+  r3.y = dot(r6.xyz, r6.xyz);
+  r3.w = dot(r0.xyw, r6.xyz);
+  r4.z = rsqrt(r3.y);
+  r3.w = saturate(r3.w * r4.z + -cb0[2].w);
+  r3.y = saturate(r3.y * cb0[2].z + 1);
+  r3.x = r3.w * r3.y + r3.x;
+  r3.yw = r5.yz * r2.ww;
+  r3.yw = round(r3.yw);
+  r6.xy = r3.yw * cb0[0].xy + r1.xy;
+  r6.z = 0;
+  r7.z = t0.SampleLevel(s0_s, r6.xyz, 0).x;
+  r3.yw = cb0[1].xy * r6.xy + cb0[1].zw;
+  r7.xy = r3.yw * r7.zz;
+  
+r7.x -= (r7.z - stereo.y) * stereo.x * fov;
+  
+  r6.xyz = r7.xyz + -r2.xyz;
+  r3.y = dot(r6.xyz, r6.xyz);
+  r3.w = dot(r0.xyw, r6.xyz);
+  r4.z = rsqrt(r3.y);
+  r3.w = saturate(r3.w * r4.z + -cb0[2].w);
+  r3.y = saturate(r3.y * cb0[2].z + 1);
+  r3.x = r3.w * r3.y + r3.x;
+  r3.yw = r5.yz * r3.zz;
+  r3.yw = round(r3.yw);
+  r6.xy = r3.yw * cb0[0].xy + r1.xy;
+  r6.z = 0;
+  r7.z = t0.SampleLevel(s0_s, r6.xyz, 0).x;
+  r3.yw = cb0[1].xy * r6.xy + cb0[1].zw;
+  r7.xy = r3.yw * r7.zz;
+  
+r7.x -= (r7.z - stereo.y) * stereo.x * fov;
+  
+  r6.xyz = r7.xyz + -r2.xyz;
+  r3.y = dot(r6.xyz, r6.xyz);
+  r3.w = dot(r0.xyw, r6.xyz);
+  r4.z = rsqrt(r3.y);
+  r3.w = saturate(r3.w * r4.z + -cb0[2].w);
+  r3.y = saturate(r3.y * cb0[2].z + 1);
+  r3.x = r3.w * r3.y + r3.x;
+  r3.yw = r5.yz * r0.zz;
+  r3.yw = round(r3.yw);
+  r6.xy = r3.yw * cb0[0].xy + r1.xy;
+  r6.z = 0;
+  r7.z = t0.SampleLevel(s0_s, r6.xyz, 0).x;
+  r3.yw = cb0[1].xy * r6.xy + cb0[1].zw;
+  r7.xy = r3.yw * r7.zz;
+  
+r7.x -= (r7.z - stereo.y) * stereo.x * fov;
+  
+  r6.xyz = r7.xyz + -r2.xyz;
+  r3.y = dot(r6.xyz, r6.xyz);
+  r3.w = dot(r0.xyw, r6.xyz);
+  r4.z = rsqrt(r3.y);
+  r3.w = saturate(r3.w * r4.z + -cb0[2].w);
+  r3.y = saturate(r3.y * cb0[2].z + 1);
+  r3.x = r3.w * r3.y + r3.x;
+  r6.x = -cb2[0].y * 3.58979313e-009 + -cb2[0].x;
+  r6.y = cb2[0].x * 3.58979313e-009 + -cb2[0].y;
+  r3.yw = r6.xy * r1.ww;
+  r3.yw = round(r3.yw);
+  r7.xy = r3.yw * cb0[0].xy + r1.xy;
+  r7.z = 0;
+  r8.z = t0.SampleLevel(s0_s, r7.xyz, 0).x;
+  r3.yw = cb0[1].xy * r7.xy + cb0[1].zw;
+  r8.xy = r3.yw * r8.zz;
+  
+r8.x -= (r8.z - stereo.y) * stereo.x * fov;
+  
+  r7.xyz = r8.xyz + -r2.xyz;
+  r3.y = dot(r7.xyz, r7.xyz);
+  r3.w = dot(r0.xyw, r7.xyz);
+  r4.z = rsqrt(r3.y);
+  r3.w = saturate(r3.w * r4.z + -cb0[2].w);
+  r3.y = saturate(r3.y * cb0[2].z + 1);
+  r3.x = r3.w * r3.y + r3.x;
+  r3.yw = r6.xy * r2.ww;
+  r3.yw = round(r3.yw);
+  r7.xy = r3.yw * cb0[0].xy + r1.xy;
+  r7.z = 0;
+  r8.z = t0.SampleLevel(s0_s, r7.xyz, 0).x;
+  r3.yw = cb0[1].xy * r7.xy + cb0[1].zw;
+  r8.xy = r3.yw * r8.zz;
+  
+r8.x -= (r8.z - stereo.y) * stereo.x * fov;
+  
+  r7.xyz = r8.xyz + -r2.xyz;
+  r3.y = dot(r7.xyz, r7.xyz);
+  r3.w = dot(r0.xyw, r7.xyz);
+  r4.z = rsqrt(r3.y);
+  r3.w = saturate(r3.w * r4.z + -cb0[2].w);
+  r3.y = saturate(r3.y * cb0[2].z + 1);
+  r3.x = r3.w * r3.y + r3.x;
+  r3.yw = r6.xy * r3.zz;
+  r3.yw = round(r3.yw);
+  r7.xy = r3.yw * cb0[0].xy + r1.xy;
+  r7.z = 0;
+  r8.z = t0.SampleLevel(s0_s, r7.xyz, 0).x;
+  r3.yw = cb0[1].xy * r7.xy + cb0[1].zw;
+  r8.xy = r3.yw * r8.zz;
+  
+r8.x -= (r8.z - stereo.y) * stereo.x * fov;
+  
+  r7.xyz = r8.xyz + -r2.xyz;
+  r3.y = dot(r7.xyz, r7.xyz);
+  r3.w = dot(r0.xyw, r7.xyz);
+  r4.z = rsqrt(r3.y);
+  r3.w = saturate(r3.w * r4.z + -cb0[2].w);
+  r3.y = saturate(r3.y * cb0[2].z + 1);
+  r3.x = r3.w * r3.y + r3.x;
+  r3.yw = r6.xy * r0.zz;
+  r3.yw = round(r3.yw);
+  r6.xy = r3.yw * cb0[0].xy + r1.xy;
+  r6.z = 0;
+  r7.z = t0.SampleLevel(s0_s, r6.xyz, 0).x;
+  r3.yw = cb0[1].xy * r6.xy + cb0[1].zw;
+  r7.xy = r3.yw * r7.zz;
+  
+r7.x -= (r7.z - stereo.y) * stereo.x * fov;
+  
+  r6.xyz = r7.xyz + -r2.xyz;
+  r3.y = dot(r6.xyz, r6.xyz);
+  r3.w = dot(r0.xyw, r6.xyz);
+  r4.z = rsqrt(r3.y);
+  r3.w = saturate(r3.w * r4.z + -cb0[2].w);
+  r3.y = saturate(r3.y * cb0[2].z + 1);
+  r3.x = r3.w * r3.y + r3.x;
+  r6.x = cb2[0].x * -0.707106769 + -r4.y;
+  r6.y = r4.y + r4.x;
+  r3.yw = r6.xy * r1.ww;
+  r3.yw = round(r3.yw);
+  r7.xy = r3.yw * cb0[0].xy + r1.xy;
+  r7.z = 0;
+  r4.w = t0.SampleLevel(s0_s, r7.xyz, 0).x;
+  r3.yw = cb0[1].xy * r7.xy + cb0[1].zw;
+  r4.xz = r3.yw * r4.ww;
+  
+r4.x -= (r4.w - stereo.y) * stereo.x * fov;
+  
+  r4.xzw = r4.xzw + -r2.xyz;
+  r3.y = dot(r4.xzw, r4.xzw);
+  r3.w = dot(r0.xyw, r4.xzw);
+  r4.x = rsqrt(r3.y);
+  r3.w = saturate(r3.w * r4.x + -cb0[2].w);
+  r3.y = saturate(r3.y * cb0[2].z + 1);
+  r3.x = r3.w * r3.y + r3.x;
+  r3.yw = r6.xy * r2.ww;
+  r3.yw = round(r3.yw);
+  r7.xy = r3.yw * cb0[0].xy + r1.xy;
+  r7.z = 0;
+  r4.w = t0.SampleLevel(s0_s, r7.xyz, 0).x;
+  r3.yw = cb0[1].xy * r7.xy + cb0[1].zw;
+  r4.xz = r3.yw * r4.ww;
+  
+r4.x -= (r4.w - stereo.y) * stereo.x * fov;
+  
+  r4.xzw = r4.xzw + -r2.xyz;
+  r3.y = dot(r4.xzw, r4.xzw);
+  r3.w = dot(r0.xyw, r4.xzw);
+  r4.x = rsqrt(r3.y);
+  r3.w = saturate(r3.w * r4.x + -cb0[2].w);
+  r3.y = saturate(r3.y * cb0[2].z + 1);
+  r3.x = r3.w * r3.y + r3.x;
+  r3.yw = r6.xy * r3.zz;
+  r3.yw = round(r3.yw);
+  r7.xy = r3.yw * cb0[0].xy + r1.xy;
+  r7.z = 0;
+  r4.w = t0.SampleLevel(s0_s, r7.xyz, 0).x;
+  r3.yw = cb0[1].xy * r7.xy + cb0[1].zw;
+  r4.xz = r3.yw * r4.ww;
+  
+r4.x -= (r4.w - stereo.y) * stereo.x * fov;
+  
+  r4.xzw = r4.xzw + -r2.xyz;
+  r3.y = dot(r4.xzw, r4.xzw);
+  r3.w = dot(r0.xyw, r4.xzw);
+  r4.x = rsqrt(r3.y);
+  r3.w = saturate(r3.w * r4.x + -cb0[2].w);
+  r3.y = saturate(r3.y * cb0[2].z + 1);
+  r3.x = r3.w * r3.y + r3.x;
+  r3.yw = r6.xy * r0.zz;
+  r3.yw = round(r3.yw);
+  r6.xy = r3.yw * cb0[0].xy + r1.xy;
+  r6.z = 0;
+  r4.w = t0.SampleLevel(s0_s, r6.xyz, 0).x;
+  r3.yw = cb0[1].xy * r6.xy + cb0[1].zw;
+  r4.xz = r3.yw * r4.ww;
+  
+r4.x -= (r4.w - stereo.y) * stereo.x * fov;
+  
+  r4.xzw = r4.xzw + -r2.xyz;
+  r3.y = dot(r4.xzw, r4.xzw);
+  r3.w = dot(r0.xyw, r4.xzw);
+  r4.x = rsqrt(r3.y);
+  r3.w = saturate(r3.w * r4.x + -cb0[2].w);
+  r3.y = saturate(r3.y * cb0[2].z + 1);
+  r3.x = r3.w * r3.y + r3.x;
+  r6.x = cb2[0].x * -5.38468914e-009 + cb2[0].y;
+  r6.y = cb2[0].y * -5.38468914e-009 + -cb2[0].x;
+  r3.yw = r6.xy * r1.ww;
+  r3.yw = round(r3.yw);
+  r7.xy = r3.yw * cb0[0].xy + r1.xy;
+  r7.z = 0;
+  r4.w = t0.SampleLevel(s0_s, r7.xyz, 0).x;
+  r3.yw = cb0[1].xy * r7.xy + cb0[1].zw;
+  r4.xz = r3.yw * r4.ww;
+  
+r4.x -= (r4.w - stereo.y) * stereo.x * fov;
+  
+  r4.xzw = r4.xzw + -r2.xyz;
+  r3.y = dot(r4.xzw, r4.xzw);
+  r3.w = dot(r0.xyw, r4.xzw);
+  r4.x = rsqrt(r3.y);
+  r3.w = saturate(r3.w * r4.x + -cb0[2].w);
+  r3.y = saturate(r3.y * cb0[2].z + 1);
+  r3.x = r3.w * r3.y + r3.x;
+  r3.yw = r6.xy * r2.ww;
+  r3.yw = round(r3.yw);
+  r7.xy = r3.yw * cb0[0].xy + r1.xy;
+  r7.z = 0;
+  r4.w = t0.SampleLevel(s0_s, r7.xyz, 0).x;
+  r3.yw = cb0[1].xy * r7.xy + cb0[1].zw;
+  r4.xz = r3.yw * r4.ww;
+  
+r4.x -= (r4.w - stereo.y) * stereo.x * fov;
+  
+  r4.xzw = r4.xzw + -r2.xyz;
+  r3.y = dot(r4.xzw, r4.xzw);
+  r3.w = dot(r0.xyw, r4.xzw);
+  r4.x = rsqrt(r3.y);
+  r3.w = saturate(r3.w * r4.x + -cb0[2].w);
+  r3.y = saturate(r3.y * cb0[2].z + 1);
+  r3.x = r3.w * r3.y + r3.x;
+  r3.yw = r6.xy * r3.zz;
+  r3.yw = round(r3.yw);
+  r7.xy = r3.yw * cb0[0].xy + r1.xy;
+  r7.z = 0;
+  r4.w = t0.SampleLevel(s0_s, r7.xyz, 0).x;
+  r3.yw = cb0[1].xy * r7.xy + cb0[1].zw;
+  r4.xz = r3.yw * r4.ww;
+  
+r4.x -= (r4.w - stereo.y) * stereo.x * fov;
+  
+  r4.xzw = r4.xzw + -r2.xyz;
+  r3.y = dot(r4.xzw, r4.xzw);
+  r3.w = dot(r0.xyw, r4.xzw);
+  r4.x = rsqrt(r3.y);
+  r3.w = saturate(r3.w * r4.x + -cb0[2].w);
+  r3.y = saturate(r3.y * cb0[2].z + 1);
+  r3.x = r3.w * r3.y + r3.x;
+  r3.yw = r6.xy * r0.zz;
+  r3.yw = round(r3.yw);
+  r6.xy = r3.yw * cb0[0].xy + r1.xy;
+  r6.z = 0;
+  r4.w = t0.SampleLevel(s0_s, r6.xyz, 0).x;
+  r3.yw = cb0[1].xy * r6.xy + cb0[1].zw;
+  r4.xz = r3.yw * r4.ww;
+  
+r4.x -= (r4.w - stereo.y) * stereo.x * fov;
+  
+  r4.xzw = r4.xzw + -r2.xyz;
+  r3.y = dot(r4.xzw, r4.xzw);
+  r3.w = dot(r0.xyw, r4.xzw);
+  r4.x = rsqrt(r3.y);
+  r3.w = saturate(r3.w * r4.x + -cb0[2].w);
+  r3.y = saturate(r3.y * cb0[2].z + 1);
+  r3.x = r3.w * r3.y + r3.x;
+  r5.x = cb2[0].x * 0.707106769 + -r4.y;
+  r3.yw = r5.xw * r1.ww;
+  r3.yw = round(r3.yw);
+  r4.xy = r3.yw * cb0[0].xy + r1.xy;
+  r4.z = 0;
+  r6.z = t0.SampleLevel(s0_s, r4.xyz, 0).x;
+  r3.yw = cb0[1].xy * r4.xy + cb0[1].zw;
+  r6.xy = r3.yw * r6.zz;
+  
+r6.x -= (r6.z - stereo.y) * stereo.x * fov;
+  
+  r4.xyz = r6.xyz + -r2.xyz;
+  r1.w = dot(r4.xyz, r4.xyz);
+  r3.y = dot(r0.xyw, r4.xyz);
+  r3.w = rsqrt(r1.w);
+  r3.y = saturate(r3.y * r3.w + -cb0[2].w);
+  r1.w = saturate(r1.w * cb0[2].z + 1);
+  r1.w = r3.y * r1.w + r3.x;
+  r3.xy = r5.xw * r2.ww;
+  r3.xy = round(r3.xy);
+  r4.xy = r3.xy * cb0[0].xy + r1.xy;
+  r4.z = 0;
+  r3.w = t0.SampleLevel(s0_s, r4.xyz, 0).x;
+  r4.xy = cb0[1].xy * r4.xy + cb0[1].zw;
+  r3.xy = r4.xy * r3.ww;
+  
+r3.x -= (r3.w - stereo.y) * stereo.x * fov;
+
+  r3.xyw = r3.xyw + -r2.xyz;
+  r2.w = dot(r3.xyw, r3.xyw);
+  r3.x = dot(r0.xyw, r3.xyw);
+  r3.y = rsqrt(r2.w);
+  r3.x = saturate(r3.x * r3.y + -cb0[2].w);
+  r2.w = saturate(r2.w * cb0[2].z + 1);
+  r1.w = r3.x * r2.w + r1.w;
+  r3.xy = r5.xw * r3.zz;
+  r3.xy = round(r3.xy);
+  r3.xy = r3.xy * cb0[0].xy + r1.xy;
+  r3.z = 0;
+  r4.z = t0.SampleLevel(s0_s, r3.xyz, 0).x;
+  r3.xy = cb0[1].xy * r3.xy + cb0[1].zw;
+  r4.xy = r3.xy * r4.zz;
+  
+r4.x -= (r4.z - stereo.y) * stereo.x * fov;
+
+  r3.xyz = r4.xyz + -r2.xyz;
+  r2.w = dot(r3.xyz, r3.xyz);
+  r3.x = dot(r0.xyw, r3.xyz);
+  r3.y = rsqrt(r2.w);
+  r3.x = saturate(r3.x * r3.y + -cb0[2].w);
+  r2.w = saturate(r2.w * cb0[2].z + 1);
+  r1.w = r3.x * r2.w + r1.w;
+  r3.xy = r5.xw * r0.zz;
+  r3.xy = round(r3.xy);
+  r3.xy = r3.xy * cb0[0].xy + r1.xy;
+  r3.z = 0;
+  r4.z = t0.SampleLevel(s0_s, r3.xyz, 0).x;
+  r1.xy = cb0[1].xy * r3.xy + cb0[1].zw;
+  r4.xy = r1.xy * r4.zz;
+  
+r4.x -= (r4.z - stereo.y) * stereo.x * fov;
+
+  r2.xyz = r4.xyz + -r2.xyz;
+  r0.z = dot(r2.xyz, r2.xyz);
+  r0.x = dot(r0.xyw, r2.xyz);
+  r0.y = rsqrt(r0.z);
+  r0.x = saturate(r0.x * r0.y + -cb0[2].w);
+  r0.y = saturate(r0.z * cb0[2].z + 1);
+  r0.x = r0.x * r0.y + r1.w;
+  r0.x = cb0[3].y * r0.x;
+  r0.x = r1.z * 8 + r0.x;
+  o0.x = saturate(-r0.x * 0.0625 + 1);
+  return;
+}

--- a/Witcher3/Helifax_Update_1.22_3DM.1.2.40/d3dx.ini
+++ b/Witcher3/Helifax_Update_1.22_3DM.1.2.40/d3dx.ini
@@ -280,6 +280,10 @@ vs-t110 = ResourceWBuffer
 Hash = d90496f029191acd
 handling = skip
 
+[ShaderOverrideHBAONormalArtifactsVS]
+Hash = 9a331a43dddf7ba1
+ps-cb13 = vs-cb12
+
 
 ;------------------------------------------------------------------------------------------------------
 ; Chain load other wrapper DLLs instead of system DLLs.


### PR DESCRIPTION
I fixed HBAO+ normal map artifacts in The Witcher 3 with DarkStarSwords pattern from https://forums.geforce.com/default/topic/897529/3d-hbao-normal-map-artefact-fix.

The fix is FOV aware as the game changes it depending on the situation. Required constant buffers are copied from the parent vertex shader which seems to have the same layout as register b12 in f9c83c25de6eaa51-ps_replace. Nevertheless some fudge constant of 1.5 seems to be necessary. 
