### PR TITLE
Fix preset restoration after transitting from one to another.

### DIFF
--- a/DirectX11/Override.h
+++ b/DirectX11/Override.h
@@ -159,8 +159,9 @@ public:
 		activated(false)
 	{}
 
-	void Activate(HackerDevice *device);
+	void Activate(HackerDevice *device, PresetOverride *prev);
 	void Deactivate(HackerDevice *device);
+	bool IsActivated();
 };
 typedef std::unordered_map<std::wstring, class PresetOverride> PresetOverrideMap;
 extern PresetOverrideMap presetOverrides;


### PR DESCRIPTION
In a relatively rare situation when transitting from one active preset to another, the original convergence/separation values stored in the previous preset is lost.

This is a quick fix to the problem. It reads the value from NVAPI only when there is no active preset. When there is already an active preset, it just take them from it and move it to the new active preset.